### PR TITLE
모바일 환경 페이지 이동  시 사이드바 안 닫히는 버그 해결

### DIFF
--- a/app/_components/sidebar/index.tsx
+++ b/app/_components/sidebar/index.tsx
@@ -6,8 +6,10 @@ import {
   ReactNode,
   SetStateAction,
   useContext,
+  useEffect,
   useState,
 } from 'react'
+import { usePathname } from 'next/navigation'
 
 import { cn } from '#/lib/utils'
 
@@ -126,6 +128,15 @@ export function SidebarTriggerClosed({ children }: ClassNameProp) {
 
 export function SidebarContainer({ children, className }: ClassNameProp) {
   const { open, pinned, setOpen, isDesktop } = useSidebar()
+
+  const pathname = usePathname()
+
+  // 라우트 변경 시 모바일에서 사이드바 닫기
+  useEffect(() => {
+    if (!isDesktop) {
+      setOpen(false)
+    }
+  }, [pathname, setOpen, isDesktop])
 
   const handleMouseLeave = () => {
     if (pinned === false) {


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🏷️ 이슈 번호 <!-- 이슈 번호 입력 -->

- close #9 

## 🧱 작업 사항

sidebarContainer 안에 usePathname과 useEffect를 사용해서 해결했습니다. 

다른 제안이 있다면 말해주세요 
